### PR TITLE
core: Fixed prepare_transmission

### DIFF
--- a/examples/echo.py
+++ b/examples/echo.py
@@ -60,9 +60,9 @@ class AV(ToxAV):
                                        "max_video_height": 1080})
         except:
             pass
-        self.prepare_transmission(
-            idx, self.jbufdc * 2, self.VADd,
-            True if self.call_type == self.TypeVideo else False)
+
+        video_enabled = True if self.call_type == self.TypeVideo else False
+        self.prepare_transmission(idx, vide_enabled)
 
     def on_end(self, idx):
         self.kill_transmission(idx)
@@ -153,7 +153,7 @@ class EchoBot(Tox):
         self.friend_add_norequest(pk)
         print('Accepted.')
 
-    def on_friend_message(self, friendId, message):
+    def on_friend_message(self, friendId, type, message):
         name = self.friend_get_name(friendId)
         print('%s: %s' % (name, message))
         print('EchoBot: %s' % message)

--- a/pytox/av.c
+++ b/pytox/av.c
@@ -530,7 +530,7 @@ ToxAV_prepare_transmission(ToxAV* self, PyObject* args)
 {
   int call_index = 0, support_video = 0;
 
-  if (!PyArg_ParseTuple(args, "iIIi", &call_index, &support_video)) {
+  if (!PyArg_ParseTuple(args, "ii", &call_index, &support_video)) {
     return NULL;
   }
 

--- a/pytox/core.c
+++ b/pytox/core.c
@@ -1454,7 +1454,7 @@ PyMethodDef Tox_methods[] = {
   },
   {
     "on_friend_message", (PyCFunction)ToxCore_callback_stub, METH_VARARGS,
-    "on_friend_message(friend_number, message)\n"
+    "on_friend_message(friend_number, type, message)\n"
     "Callback for receiving friend messages, default implementation does "
     "nothing."
   },


### PR DESCRIPTION
* Fixed the prepare_transmission function that required a strange number
  of parameters.

* Fixed docs where appropriate.

* Made examples PEP8 compliant.

Signed-off-by: mr.Shu <mr@shu.io>